### PR TITLE
fix: app crash when enable new architecture

### DIFF
--- a/android/src/main/java/com/reactnativefullscreennotificationincomingcall/FullScreenNotificationIncomingCallModule.java
+++ b/android/src/main/java/com/reactnativefullscreennotificationincomingcall/FullScreenNotificationIncomingCallModule.java
@@ -88,7 +88,6 @@ public class FullScreenNotificationIncomingCallModule extends ReactContextBaseJa
     getReactApplicationContext().stopService(intent);
   }
 
-  @ReactMethod
   public static void sendEventToJs(String eventName, @Nullable WritableMap params) {
     reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
   }

--- a/android/src/main/java/com/reactnativefullscreennotificationincomingcall/IncomingCallActivity.java
+++ b/android/src/main/java/com/reactnativefullscreennotificationincomingcall/IncomingCallActivity.java
@@ -97,7 +97,6 @@ public class IncomingCallActivity extends AppCompatActivity implements DefaultHa
       Fragment reactNativeFragment = new ReactFragment.Builder()
         .setComponentName(mainComponent)
         .setLaunchOptions(bundle)
-        .setFabricEnabled(false)
         .build();
 
       getSupportFragmentManager()


### PR DESCRIPTION
**Overview**:
- Fix: https://github.com/linhvovan29546/react-native-full-screen-notification-incoming-call/issues/64
- Remove `setFabricEnabled(false)`