### PR TITLE
chore: update picasso to 2.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "com.airbnb.android:lottie:5.1.1" // create ui animation
-  implementation 'com.squareup.picasso:picasso:2.71828' 
+  implementation 'com.squareup.picasso:picasso:2.8'
   implementation "androidx.core:core:$core_version"
 }
 


### PR DESCRIPTION
In [release 2.8](https://github.com/square/picasso/releases/tag/2.8) they migrated off 'android.support' libs to 'androidx' ones. Update to this version will allow users to disable [jetifier](https://developer.android.com/tools/jetifier).